### PR TITLE
Correct the RetroArch hotkeys

### DIFF
--- a/docs/emulators/steamos/retroarch.md
+++ b/docs/emulators/steamos/retroarch.md
@@ -408,8 +408,8 @@ For more information: [https://docs.libretro.com/guides/overrides/](https://docs
 | Menu               | `L3` + `R3`             |
 | Exit               | `Select` + `Start `     |
 | Pause/Unpause      | `Select` + `A`          |
-| Fast Forward       | `Select` + `R2`         |
-| Rewind             | `Select` + `L1`         |
+| Fast Forward (Toggle)       | `Select` + `R2`         |
+| Rewind             | `Select` + `L2`         |
 | Save State         | `Select` + `R1`         |
 | Load State         | `Select` + `L1`         |
 | Next Save Slot     | `Select` + `DPAD Right` |


### PR DESCRIPTION
This corrects the rewind key. L2, not L1.

It also clarifies that the fast forward key is TOGGLE, not HOLD. Well, it's information that I personally think is useful.