### PR TITLE
Update tools-and-guides.md Syncthing Ryujinx Fix

### DIFF
--- a/docs/community-creations/steamos/tools-and-guides.md
+++ b/docs/community-creations/steamos/tools-and-guides.md
@@ -55,7 +55,7 @@ RetroArch SaveData:
 
 Ryujinx SaveData:
 
-    path="/home/deck/.config/Ryujinx/bis/user/"
+    path="/home/deck/.config/Ryujinx/bis/"
 
 RPCS3 SaveData:
     


### PR DESCRIPTION
Due to how Ryujinx saves folders are named in order of game opening order, need to sync entire bis folder instead of just user saves folder. This way between devices, not only are the saves synced, but between devices the same folder names will be linked in the same order.