### PR TITLE
Update Patreon notices

### DIFF
--- a/docs/frequently-asked-questions/windows/index.md
+++ b/docs/frequently-asked-questions/windows/index.md
@@ -4,23 +4,11 @@
 
 [TOC]
 
-## Where do I get EmuDeck for Windows?
-EmuDeck for Windows is only available through the Patreon: [https://www.patreon.com/dragoonDorise](https://www.patreon.com/dragoonDorise)
-
-## Which Patreon tiers includes EmuDeck for Windows?
-The  "Early Access" and "EmuDeck Fan" tiers.
-
-## I am subscribed to the Patreon, how do I receive support on Discord?
-Read this Patreon article to link your Patreon account to your Discord, [https://support.patreon.com/hc/en-us/articles/212052266-Getting-Discord-access](https://support.patreon.com/hc/en-us/articles/212052266-Getting-Discord-access). After you have linked your Patreon account, you will have access to the Windows channel.
-
 ## Does EmuDeck for Windows include the same set of emulators as SteamOS?
 No, but more emulators are being added to EmuDeck for Windows over time.
 
 ## Will EmuDeck for Windows work on the ROG Ally? How about the Aya Neo?
 Yes! EmuDeck for Windows also comes with per-device optimizations for handhelds like the ROG Ally and the Aya Neo.
-
-## Is EmuDeck for Windows only available through Patreon? 
-Yes, as of today, EmuDeck for Windows is only available through Patreon. We are still considering how and when will EmuDeck be released to the public.
 
 ## Can I install it on more than one device?
 Sure!

--- a/docs/how-to-install-emudeck/windows/index.md
+++ b/docs/how-to-install-emudeck/windows/index.md
@@ -1,7 +1,5 @@
 # How to Install EmuDeck for Windows
 
-> ⚠️ EmuDeck for Windows is only available through the Patreon: [https://www.patreon.com/dragoonDorise](https://www.patreon.com/dragoonDorise) in the  "Early Access" and "EmuDeck Fan" tiers. There is currently no ETA for the public release. ⚠️
-
 [TOC]
 
 ***

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,15 +33,13 @@ Could you do everything EmuDeck does on your own? You sure could, but now you do
 
 ### EmuDeck for Windows
 
-EmuDeck for Windows is ready for testing through EmuDeck's Patreon, found here: [https://www.patreon.com/dragoonDorise](https://www.patreon.com/dragoonDorise). It is only available through the "Early Access" or "EmuDeck Fan" tiers. 
-
 EmuDeck for Windows is still in development. Its feature suite is not currently at parity with EmuDeck for SteamOS but more will be added over time. 
 
-For more information, read [EmuDeck for Window's FAQ](./frequently-asked-questions/windows/index.md).
+For more information, read [EmuDeck for Windows FAQ](./frequently-asked-questions/windows/index.md).
 
 ### EmuDeck for Android
 
-EmuDeck for Android development is currently on pause until EmuDeck for Windows is released. 
+EmuDeck for Android is ready for testing through EmuDeck's Patreon, found here: [https://www.patreon.com/dragoonDorise](https://www.patreon.com/dragoonDorise). It is only available through the "Early Access" or "EmuDeck Fan" tiers. 
 
 ***
 


### PR DESCRIPTION
This removes the Patreon notices on the wiki for the Windows version as it is now publicly released.

A notice for Android was added instead, though I'm not entirely sure if it's fully accurate as I just copied the wording from the Windows notice.