### PR TITLE
Add dropout.tv to list of cloud services supported

### DIFF
--- a/docs/tools/steamos/cloud-services.md
+++ b/docs/tools/steamos/cloud-services.md
@@ -60,6 +60,7 @@ The Cloud Services Manager (CSM) handles two types of services:
 | Crunchyroll                | [https://www.crunchyroll.com/](https://www.crunchyroll.com/)      |
 | Discord                    | [https://discord.com/](https://discord.com/)               |
 | Disney+                    | [https://www.disneyplus.com/](https://www.disneyplus.com/)        |
+| Dropout                    | [https://dopout.tv](https://dropout.tv)                |
 | Emby *                     | [https://emby.media/](https://emby.media/)               |
 | HBO Max                    | [https://www.hbomax.com/](https://www.hbomax.com/)            |
 | Home Assistant *           | [https://demo.home-assistant.io/](https://demo.home-assistant.io/)    |

--- a/docs/tools/steamos/cloud-services.md
+++ b/docs/tools/steamos/cloud-services.md
@@ -60,7 +60,7 @@ The Cloud Services Manager (CSM) handles two types of services:
 | Crunchyroll                | [https://www.crunchyroll.com/](https://www.crunchyroll.com/)      |
 | Discord                    | [https://discord.com/](https://discord.com/)               |
 | Disney+                    | [https://www.disneyplus.com/](https://www.disneyplus.com/)        |
-| Dropout                    | [https://dopout.tv](https://dropout.tv)                |
+| Dropout                    | [https://dropout.tv](https://dropout.tv)                 |
 | Emby *                     | [https://emby.media/](https://emby.media/)               |
 | HBO Max                    | [https://www.hbomax.com/](https://www.hbomax.com/)            |
 | Home Assistant *           | [https://demo.home-assistant.io/](https://demo.home-assistant.io/)    |


### PR DESCRIPTION
Per https://github.com/dragoonDorise/EmuDeck/pull/1219, support for Dropout.tv (a great service!) has been added.
This catches up the docs with that update.