### PR TITLE
Remove ryujinx patreon link

### DIFF
--- a/docs/donations.md
+++ b/docs/donations.md
@@ -110,7 +110,7 @@ No donation link found at this time.
 
 ## Ryujinx
 
-* [Patreon](https://www.patreon.com/ryujinx)
+No donation link for Greem's fork at this time.
 
 ## ScummVM
 


### PR DESCRIPTION
Because it got took down and also because a particular company got it.