### PR TITLE
Edit a few information about shadPS4

### DIFF
--- a/docs/emulators/steamos/shadps4.md
+++ b/docs/emulators/steamos/shadps4.md
@@ -3,13 +3,13 @@
 
 Website: [https://shadps4.net/](https://shadps4.net/)
 
-FAQ: [https://shadps4.net/index.php/faq/](https://shadps4.net/index.php/faq/)
+FAQ: [https://shadps4.net/about/faq/](https://shadps4.net/about/faq/)
 
 GitHub: [https://github.com/shadps4-emu/shadPS4](https://github.com/shadps4-emu/shadPS4)
 
-Compatibility List: [https://github.com/shadps4-emu/shadps4-game-compatibility](https://github.com/shadps4-emu/shadps4-game-compatibility)
+Compatibility List: [https://github.com/shadps4-compatibility/shadps4-game-compatibility/](https://github.com/shadps4-compatibility/shadps4-game-compatibility/)
 
-shadps4 Wiki: [https://wiki.shadps4.net/index.php?title=Main_Page](https://shadps4.net/compatibility)
+shadps4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/shadps4-emu/shadPS4/wiki)
 
 ***
 

--- a/docs/emulators/steamos/shadps4.md
+++ b/docs/emulators/steamos/shadps4.md
@@ -1,4 +1,4 @@
-# ShadPS4 is an experimental Sony Playstation 4 Emulator.
+# shadPS4 is an experimental Sony Playstation 4 Emulator.
 
 
 Website: [https://shadps4.net/](https://shadps4.net/)
@@ -9,41 +9,41 @@ GitHub: [https://github.com/shadps4-emu/shadPS4](https://github.com/shadps4-emu/
 
 Compatibility List: [https://github.com/shadps4-compatibility/shadps4-game-compatibility/](https://github.com/shadps4-compatibility/shadps4-game-compatibility/)
 
-shadps4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/shadps4-emu/shadPS4/wiki)
+shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/shadps4-emu/shadPS4/wiki)
 
 ***
 
-## shadps4 Table of Contents
+## shadPS4 Table of Contents
 
-1. [Getting Started with shadps4](#getting-started-with-shadps4)
+1. [Getting Started with shadPS4](#getting-started-with-shadps4)
     - [Configuration](#shadps4-configuration)
-    - [shadps4 Folder Locations](#shadps4-folder-locations)
-    - [How to Update shadps4](#how-to-update-shadps4)
-    - [How to Launch shadps4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
+    - [shadPS4 Folder Locations](#shadps4-folder-locations)
+    - [How to Update shadPS4](#how-to-update-shadps4)
+    - [How to Launch shadPS4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
     - [File Formats](#shadps4-file-formats)
         - [PKG and RAP File Format](#pkg-and-rap-file-format)
     - [Steam ROM Manager Parsers](#steam-rom-manager-parsers)
 
 ***
 
-## Getting Started with shadps4
+## Getting Started with shadPS4
 [Back to the Top](#shadps4-table-of-contents)
 
-In order to play a game on shadps4, you need to install the games through the shadps4 UI. In desktop mode, open shadps4, either in the application menu or through its shortcut in `Emulation/tools/launchers/shadps4.sh`. In shadps4, click File, click Install Packages(PKG) and select your game, this will install it to Emulation/storage/shadps4/games
+In order to play a game on shadPS4, you need to install the games through the shadPS4 UI. In desktop mode, open shadPS4, either in the application menu or through its shortcut in `Emulation/tools/launchers/shadps4.sh`. In shadPS4, click File, click Install Packages(PKG) and select your game, this will install it to Emulation/storage/shadps4/games
 
-Read the [Configuration](#shadps4-configuration) section to learn more about shadps4 and its folder locations.
+Read the [Configuration](#shadps4-configuration) section to learn more about shadPS4 and its folder locations.
 
 To launch your ROMs in game mode, use Steam ROM Manager and use one of the following parsers to play your Playstation 4 ROMs:
 
 * `ES-DE`
-    * To play PS4 games in ES-DE, see [How to Configure shadps4 to Work With ES-DE and Pegasus](#how-to-configure-shadps4-to-work-with-es-de-and-pegasus)
+    * To play PS4 games in ES-DE, see [How to Configure shadPS4 to Work With ES-DE and Pegasus](#how-to-configure-shadps4-to-work-with-es-de-and-pegasus)
 * `Sony PlayStation 4 - ShadPS4 (Shortcut)`
     * Read the [File Formats](#shadps4-file-formats) section to learn more about these various file formats
 * `Emulators`
 
 ***
 
-### shadps4 Configuration
+### shadPS4 Configuration
 [Back to the Top](#shadps4-table-of-contents)
 
 * Type of Emulator: AppImage
@@ -54,7 +54,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 * Saves:
     * Folder: `Emulation/saves/shadps4/saves`
 
-* Your game will not show in the shadps4 UI until you add it manually through the `Install Packages(PKG)` option under `File` in the top left.
+* Your game will not show in the shadPS4 UI until you add it manually through the `Install Packages(PKG)` option under `File` in the top left.
 
 * No BIOS is needed for shadPS4
 
@@ -65,7 +65,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 
 ***
 
-### shadps4 Folder Locations
+### shadPS4 Folder Locations
 [Back to the Top](#shadps4-table-of-contents)
 
 These file locations apply regardless of where you chose to install EmuDeck (to your internal SSD, to your SD Card, or elsewhere). Some emulator configuration files will be located on the internal SSD as listed below.
@@ -94,7 +94,7 @@ shadps4/
 
 ***
 
-### How to Update shadps4
+### How to Update shadPS4
 [Back to the Top](#shadps4-table-of-contents)
 
 * Through the `Update your Emulators` section on the `Manage Emulators` page in the `EmuDeck` application
@@ -102,17 +102,17 @@ shadps4/
 
 ***
 
-### How to Launch shadps4 in Desktop Mode
+### How to Launch shadPS4 in Desktop Mode
 [Back to the Top](#shadps4-table-of-contents)
 
-* Launch `ShadPS4 AppImage` from the Applications Launcher (Steam Deck icon in the bottom left of the taskbar)
+* Launch `shadPS4 AppImage` from the Applications Launcher (Steam Deck icon in the bottom left of the taskbar)
 * Launch the script from `Emulation/tools/launchers`, `shadps4.sh`
 * Launch the emulator from `Steam` after adding it via the `Emulators` parser in `Steam ROM Manager`
 
 
 ***
 
-### shadps4 File Formats
+### shadPS4 File Formats
 [Back to the Top](#shadps4-table-of-contents)
 
 - [PKG Format](#pkg-and-rap-file-format)
@@ -120,7 +120,7 @@ shadps4/
 #### PKG and RAP File Format
 [Back to the Top](#shadps4-file-formats)
 
-Install `.pkg` files directly through the shadps4 GUI. `.pkg` files are installed to `Emulation/storage/shadps4/games/`.
+Install `.pkg` files directly through the shadPS4 GUI. `.pkg` files are installed to `Emulation/storage/shadps4/games/`.
 
 After that right click on the installed game and select "Create Desktop", copy the new .desktop file you'll find in your Desktop to `Emulation/roms/ps4/shortcuts/`
 
@@ -133,13 +133,13 @@ After that right click on the installed game and select "Create Desktop", copy t
 
 ***
 
-### How to Configure shadps4 to Work With ES-DE and Pegasus
+### How to Configure shadPS4 to Work With ES-DE and Pegasus
 [Back to the Top](#shadps4-table-of-contents)
 
 ## AppImage
 
-1. In `Desktop Mode`, open shadps4
-2. Skip this step if you have already added your games to shadps4:
+1. In `Desktop Mode`, open shadPS4
+2. Skip this step if you have already added your games to shadPS4:
     * Either:
         * In the top left click, `File`, click `Install Packages (PKG)`, and install your PKG
         * For more information, read the [File Formats](#shadps4-file-formats) section
@@ -147,17 +147,17 @@ After that right click on the installed game and select "Create Desktop", copy t
 4. On your desktop, you should see an icon for your game. Move this icon to `Emulation/roms/ps4/shortcuts`
     * If your desktop shortcut contains special icons any special symbols (Ex: the copyright symbol, `©`), rename the desktop file to remove these symbols.
         * For example, rename `God Of War® Collection.desktop` to `God Of War Collection.desktop`, removing the `©` after `War`
-5. (Optional) If the desktop file is opening shadps4 instead of the game:
+5. (Optional) If the desktop file is opening shadPS4 instead of the game:
     * In Desktop Mode, right click the desktop file
     * Click `Properties`
     * On the `General` tab, click `Change` to the right of the `Open With` line
-    * Under `Application Preference Order`, click `shadps4`
+    * Under `Application Preference Order`, click `shadPS4`
     * Click `Remove` on the right
     * Click `Apply` in the bottom left and click `OK`
     * The desktop file will not work in Desktop Mode, but will launch the game directly either through a terminal or through ES-DE
 6. Your game should now show up in and launch directly from ES-DE and Pegasus
 
-If you get an `Invalid file or folder` error message, you will need to change the `Alternative Emulator` in ES-DE for PlayStation 4 to `shadps4 Shortcut [Standalone]`.
+If you get an `Invalid file or folder` error message, you will need to change the `Alternative Emulator` in ES-DE for PlayStation 4 to `shadPS4 Shortcut [Standalone]`.
 
 You may also do this on a per-game basis if you are using a mix of folders and PKGs. On a game, press the `select ` button, scroll down and select `EDIT THIS GAME'S METADATA`, scroll down and select `ALTERNATIVE EMULATOR`, select PS4 and select the corresponding format.
 

--- a/docs/emulators/steamos/shadps4.md
+++ b/docs/emulators/steamos/shadps4.md
@@ -21,7 +21,6 @@ shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/s
     - [How to Update shadPS4](#how-to-update-shadps4)
     - [How to Launch shadPS4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
     - [File Formats](#shadps4-file-formats)
-    - [Steam ROM Manager Parsers](#steam-rom-manager-parsers)
 
 ***
 
@@ -113,13 +112,6 @@ shadps4/
 [Back to the Top](#shadps4-table-of-contents)
 
 shadPS4 uses normal folder format for games, simply place your game folder in `Emulation/storage/shadps4/games` to have your games show up in the UI.
-
-***
-
-### Steam ROM Manager Parsers
-[Back to the Top](#shadps4-table-of-contents)
-
-* PKG Format: Use the `Sony PlayStation 4 - ShadPS4 (Shortcut)` parser
 
 ***
 

--- a/docs/emulators/steamos/shadps4.md
+++ b/docs/emulators/steamos/shadps4.md
@@ -21,7 +21,6 @@ shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/s
     - [How to Update shadPS4](#how-to-update-shadps4)
     - [How to Launch shadPS4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
     - [File Formats](#shadps4-file-formats)
-        - [PKG and RAP File Format](#pkg-and-rap-file-format)
     - [Steam ROM Manager Parsers](#steam-rom-manager-parsers)
 
 ***
@@ -29,7 +28,7 @@ shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/s
 ## Getting Started with shadPS4
 [Back to the Top](#shadps4-table-of-contents)
 
-In order to play a game on shadPS4, you need to install the games through the shadPS4 UI. In desktop mode, open shadPS4, either in the application menu or through its shortcut in `Emulation/tools/launchers/shadps4.sh`. In shadPS4, click File, click Install Packages(PKG) and select your game, this will install it to Emulation/storage/shadps4/games
+In order to play a game on shadPS4, you need to put your game folder in the `Emulation/storage/shadps4/games` folder.
 
 Read the [Configuration](#shadps4-configuration) section to learn more about shadPS4 and its folder locations.
 
@@ -37,7 +36,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 
 * `ES-DE`
     * To play PS4 games in ES-DE, see [How to Configure shadPS4 to Work With ES-DE and Pegasus](#how-to-configure-shadps4-to-work-with-es-de-and-pegasus)
-* `Sony PlayStation 4 - ShadPS4 (Shortcut)`
+* `Sony PlayStation 4 - shadPS4 (Shortcut)`
     * Read the [File Formats](#shadps4-file-formats) section to learn more about these various file formats
 * `Emulators`
 
@@ -54,9 +53,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 * Saves:
     * Folder: `Emulation/saves/shadps4/saves`
 
-* Your game will not show in the shadPS4 UI until you add it manually through the `Install Packages(PKG)` option under `File` in the top left.
-
-* No BIOS is needed for shadPS4
+* BIOS: You will need firmware modules for some games to work, more information can be found [here](https://github.com/shadps4-emu/shadPS4/wiki/I.-Quick-start-%5BUsers%5D#4-dumping-firmware-modules)
 
 #### Works With
 * Steam ROM Manager
@@ -115,14 +112,7 @@ shadps4/
 ### shadPS4 File Formats
 [Back to the Top](#shadps4-table-of-contents)
 
-- [PKG Format](#pkg-and-rap-file-format)
-
-#### PKG and RAP File Format
-[Back to the Top](#shadps4-file-formats)
-
-Install `.pkg` files directly through the shadPS4 GUI. `.pkg` files are installed to `Emulation/storage/shadps4/games/`.
-
-After that right click on the installed game and select "Create Desktop", copy the new .desktop file you'll find in your Desktop to `Emulation/roms/ps4/shortcuts/`
+shadPS4 uses normal folder format for games, simply place your game folder in `Emulation/storage/shadps4/games` to have your games show up in the UI.
 
 ***
 
@@ -140,9 +130,7 @@ After that right click on the installed game and select "Create Desktop", copy t
 
 1. In `Desktop Mode`, open shadPS4
 2. Skip this step if you have already added your games to shadPS4:
-    * Either:
-        * In the top left click, `File`, click `Install Packages (PKG)`, and install your PKG
-        * For more information, read the [File Formats](#shadps4-file-formats) section
+    * Add your game folder to the `Emulation/storage/shadps4/games` folder. For more information, read the [File Formats](#shadps4-file-formats) section
 3. Right click your game, click `Create Shortcut`, click `Create Desktop Shortcut`
 4. On your desktop, you should see an icon for your game. Move this icon to `Emulation/roms/ps4/shortcuts`
     * If your desktop shortcut contains special icons any special symbols (Ex: the copyright symbol, `©`), rename the desktop file to remove these symbols.
@@ -159,7 +147,7 @@ After that right click on the installed game and select "Create Desktop", copy t
 
 If you get an `Invalid file or folder` error message, you will need to change the `Alternative Emulator` in ES-DE for PlayStation 4 to `shadPS4 Shortcut [Standalone]`.
 
-You may also do this on a per-game basis if you are using a mix of folders and PKGs. On a game, press the `select ` button, scroll down and select `EDIT THIS GAME'S METADATA`, scroll down and select `ALTERNATIVE EMULATOR`, select PS4 and select the corresponding format.
+On a game, press the `select ` button, scroll down and select `EDIT THIS GAME'S METADATA`, scroll down and select `ALTERNATIVE EMULATOR`, select PS4 and select the corresponding format.
 
 Refer to [https://gitlab.com/es-de/emulationstation-de/-/blob/master/USERGUIDE.md#sony-playstation-4](https://gitlab.com/es-de/emulationstation-de/-/blob/master/USERGUIDE.md#sony-playstation-4), for additional information.
 

--- a/docs/emulators/windows/shadps4.md
+++ b/docs/emulators/windows/shadps4.md
@@ -3,13 +3,13 @@
 
 Website: [https://shadps4.net/](https://shadps4.net/)
 
-FAQ: [https://shadps4.net/index.php/faq/](https://shadps4.net/index.php/faq/)
+FAQ: [https://shadps4.net/about/faq/](https://shadps4.net/about/faq/)
 
 GitHub: [https://github.com/shadps4-emu/shadPS4](https://github.com/shadps4-emu/shadPS4)
 
-Compatibility List: [https://github.com/shadps4-emu/shadps4-game-compatibility](https://github.com/shadps4-emu/shadps4-game-compatibility)
+Compatibility List: [https://github.com/shadps4-compatibility/shadps4-game-compatibility/](https://github.com/shadps4-compatibility/shadps4-game-compatibility/)
 
-shadps4 Wiki: [https://wiki.shadps4.net/index.php?title=Main_Page](https://shadps4.net/compatibility)
+shadps4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/shadps4-emu/shadPS4/wiki)
 
 ***
 

--- a/docs/emulators/windows/shadps4.md
+++ b/docs/emulators/windows/shadps4.md
@@ -21,7 +21,6 @@ shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/s
     - [How to Update shadPS4](#how-to-update-shadps4)
     - [How to Launch shadPS4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
     - [File Formats](#shadps4-file-formats)
-    - [Steam ROM Manager Parsers](#steam-rom-manager-parsers)
 
 ***
 
@@ -97,13 +96,6 @@ shadps4/
 [Back to the Top](#shadps4-table-of-contents)
 
 shadPS4 uses normal folder format for games, simply place your game folder in `Emulation/storage/shadps4/games` to have your games show up in the UI.
-
-***
-
-### Steam ROM Manager Parsers
-[Back to the Top](#shadps4-table-of-contents)
-
-* PKG Format: Use the `Sony PlayStation 4 - ShadPS4 (Shortcut)` parser
 
 ***
 

--- a/docs/emulators/windows/shadps4.md
+++ b/docs/emulators/windows/shadps4.md
@@ -1,4 +1,4 @@
-# ShadPS4 is an experimental Sony Playstation 4 Emulator.
+# shadPS4 is an experimental Sony Playstation 4 Emulator.
 
 
 Website: [https://shadps4.net/](https://shadps4.net/)
@@ -9,41 +9,41 @@ GitHub: [https://github.com/shadps4-emu/shadPS4](https://github.com/shadps4-emu/
 
 Compatibility List: [https://github.com/shadps4-compatibility/shadps4-game-compatibility/](https://github.com/shadps4-compatibility/shadps4-game-compatibility/)
 
-shadps4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/shadps4-emu/shadPS4/wiki)
+shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/shadps4-emu/shadPS4/wiki)
 
 ***
 
-## shadps4 Table of Contents
+## shadPS4 Table of Contents
 
-1. [Getting Started with shadps4](#getting-started-with-shadps4)
+1. [Getting Started with shadPS4](#getting-started-with-shadps4)
     - [Configuration](#shadps4-configuration)
-    - [shadps4 Folder Locations](#shadps4-folder-locations)
-    - [How to Update shadps4](#how-to-update-shadps4)
-    - [How to Launch shadps4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
+    - [shadPS4 Folder Locations](#shadps4-folder-locations)
+    - [How to Update shadPS4](#how-to-update-shadps4)
+    - [How to Launch shadPS4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
     - [File Formats](#shadps4-file-formats)
         - [PKG and RAP File Format](#pkg-and-rap-file-format)
     - [Steam ROM Manager Parsers](#steam-rom-manager-parsers)
 
 ***
 
-## Getting Started with shadps4
+## Getting Started with shadPS4
 [Back to the Top](#shadps4-table-of-contents)
 
-In order to play a game on shadps4, you need to install the games through the shadps4 UI. In desktop mode, open shadps4, either in the application menu or through its shortcut in `Emulation/tools/launchers/shadps4.ps1`. In shadps4, click File, click Install Packages(PKG) and select your game, this will install it to Emulation/storage/shadps4/games
+In order to play a game on shadPS4, you need to install the games through the shadPS4 UI. In desktop mode, open shadPS4, either in the application menu or through its shortcut in `Emulation/tools/launchers/shadps4.ps1`. In shadPS4, click File, click Install Packages(PKG) and select your game, this will install it to Emulation/storage/shadps4/games
 
-Read the [Configuration](#shadps4-configuration) section to learn more about shadps4 and its folder locations.
+Read the [Configuration](#shadps4-configuration) section to learn more about shadPS4 and its folder locations.
 
 To launch your ROMs in game mode, use Steam ROM Manager and use one of the following parsers to play your Playstation 4 ROMs:
 
 * `ES-DE`
-    * To play PS4 games in ES-DE, see [How to Configure shadps4 to Work With ES-DE and Pegasus](#how-to-configure-shadps4-to-work-with-es-de-and-pegasus)
-* `Sony PlayStation 4 - ShadPS4 (Shortcut)`
+    * To play PS4 games in ES-DE, see [How to Configure shadPS4 to Work With ES-DE and Pegasus](#how-to-configure-shadps4-to-work-with-es-de-and-pegasus)
+* `Sony PlayStation 4 - shadPS4 (Shortcut)`
     * Read the [File Formats](#shadps4-file-formats) section to learn more about these various file formats
 * `Emulators`
 
 ***
 
-### shadps4 Configuration
+### shadPS4 Configuration
 [Back to the Top](#shadps4-table-of-contents)
 
 * Storage Location: `Emulation/storage/shadps4/games`
@@ -52,7 +52,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 * Saves:
     * Folder: `Emulation/saves/shadps4/saves`
 
-* Your game will not show in the shadps4 UI until you add it manually through the `Install Packages(PKG)` option under `File` in the top left.
+* Your game will not show in the shadPS4 UI until you add it manually through the `Install Packages(PKG)` option under `File` in the top left.
 
 * No BIOS is needed for shadPS4
 
@@ -63,7 +63,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 
 ***
 
-### shadps4 Folder Locations
+### shadPS4 Folder Locations
 [Back to the Top](#shadps4-table-of-contents)
 
 These file locations apply regardless of where you chose to install EmuDeck (to your internal SSD, to your SD Card, or elsewhere). Some emulator configuration files will be located on the internal SSD as listed below.
@@ -80,23 +80,23 @@ shadps4/
 
 ***
 
-### How to Update shadps4
+### How to Update shadPS4
 [Back to the Top](#shadps4-table-of-contents)
 
 * Through the `Update your Emulators` section on the `Manage Emulators` page in the `EmuDeck` application
 
 ***
 
-### How to Launch shadps4 in Desktop Mode
+### How to Launch shadPS4 in Desktop Mode
 [Back to the Top](#shadps4-table-of-contents)
 
-* Launch `ShadPS4` from the Start Menu/EmuDeck (Steam Deck icon in the bottom left of the taskbar)
+* Launch `shadPS4` from the Start Menu/EmuDeck (Steam Deck icon in the bottom left of the taskbar)
 * Launch the script from `Emulation/tools/launchers`, `shadps4.sh`
 * Launch the emulator from `Steam` after adding it via the `Emulators` parser in `Steam ROM Manager`
 
 ***
 
-### shadps4 File Formats
+### shadPS4 File Formats
 [Back to the Top](#shadps4-table-of-contents)
 
 - [PKG Format](#pkg-and-rap-file-format)
@@ -104,7 +104,7 @@ shadps4/
 #### PKG and RAP File Format
 [Back to the Top](#shadps4-file-formats)
 
-Install `.pkg` files directly through the shadps4 GUI. `.pkg` files are installed to `Emulation/storage/shadps4/games/`.
+Install `.pkg` files directly through the shadPS4 GUI. `.pkg` files are installed to `Emulation/storage/shadps4/games/`.
 
 After that right click on the installed game and select "Create Desktop", copy the new .desktop file you'll find in your Desktop to `Emulation/roms/ps4/shortcuts/`
 
@@ -117,13 +117,13 @@ After that right click on the installed game and select "Create Desktop", copy t
 
 ***
 
-### How to Configure shadps4 to Work With ES-DE and Pegasus
+### How to Configure shadPS4 to Work With ES-DE and Pegasus
 [Back to the Top](#shadps4-table-of-contents)
 
 ## AppImage
 
-1. In `Desktop Mode`, open shadps4
-2. Skip this step if you have already added your games to shadps4:
+1. In `Desktop Mode`, open shadPS4
+2. Skip this step if you have already added your games to shadPS4:
     * Either:
         * In the top left click, `File`, click `Install Packages (PKG)`, and install your PKG
         * For more information, read the [File Formats](#shadps4-file-formats) section
@@ -131,17 +131,17 @@ After that right click on the installed game and select "Create Desktop", copy t
 4. On your desktop, you should see an icon for your game. Move this icon to `Emulation/roms/ps4/shortcuts`
     * If your desktop shortcut contains special icons any special symbols (Ex: the copyright symbol, `©`), rename the desktop file to remove these symbols.
         * For example, rename `God Of War® Collection.lnk` to `God Of War Collection.lnk`, removing the `©` after `War`
-5. (Optional) If the desktop file is opening shadps4 instead of the game:
+5. (Optional) If the desktop file is opening shadPS4 instead of the game:
     * In Desktop Mode, right click the desktop file
     * Click `Properties`
     * On the `General` tab, click `Change` to the right of the `Open With` line
-    * Under `Application Preference Order`, click `shadps4`
+    * Under `Application Preference Order`, click `shadPS4`
     * Click `Remove` on the right
     * Click `Apply` in the bottom left and click `OK`
     * The desktop file will not work in Desktop Mode, but will launch the game directly either through a terminal or through ES-DE
 6. Your game should now show up in and launch directly from ES-DE and Pegasus
 
-If you get an `Invalid file or folder` error message, you will need to change the `Alternative Emulator` in ES-DE for PlayStation 4 to `shadps4 Shortcut [Standalone]`.
+If you get an `Invalid file or folder` error message, you will need to change the `Alternative Emulator` in ES-DE for PlayStation 4 to `shadPS4 Shortcut [Standalone]`.
 
 You may also do this on a per-game basis if you are using a mix of folders and PKGs. On a game, press the `select ` button, scroll down and select `EDIT THIS GAME'S METADATA`, scroll down and select `ALTERNATIVE EMULATOR`, select PS4 and select the corresponding format.
 

--- a/docs/emulators/windows/shadps4.md
+++ b/docs/emulators/windows/shadps4.md
@@ -21,7 +21,6 @@ shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/s
     - [How to Update shadPS4](#how-to-update-shadps4)
     - [How to Launch shadPS4 in Desktop Mode](#how-to-launch-shadps4-in-desktop-mode)
     - [File Formats](#shadps4-file-formats)
-        - [PKG and RAP File Format](#pkg-and-rap-file-format)
     - [Steam ROM Manager Parsers](#steam-rom-manager-parsers)
 
 ***
@@ -29,7 +28,7 @@ shadPS4 Wiki: [https://github.com/shadps4-emu/shadPS4/wiki](https://github.com/s
 ## Getting Started with shadPS4
 [Back to the Top](#shadps4-table-of-contents)
 
-In order to play a game on shadPS4, you need to install the games through the shadPS4 UI. In desktop mode, open shadPS4, either in the application menu or through its shortcut in `Emulation/tools/launchers/shadps4.ps1`. In shadPS4, click File, click Install Packages(PKG) and select your game, this will install it to Emulation/storage/shadps4/games
+In order to play a game on shadPS4, you need to put your game folder in the `Emulation/storage/shadps4/games` folder.
 
 Read the [Configuration](#shadps4-configuration) section to learn more about shadPS4 and its folder locations.
 
@@ -52,9 +51,7 @@ To launch your ROMs in game mode, use Steam ROM Manager and use one of the follo
 * Saves:
     * Folder: `Emulation/saves/shadps4/saves`
 
-* Your game will not show in the shadPS4 UI until you add it manually through the `Install Packages(PKG)` option under `File` in the top left.
-
-* No BIOS is needed for shadPS4
+* BIOS: You will need firmware modules for some games to work, more information can be found [here](https://github.com/shadps4-emu/shadPS4/wiki/I.-Quick-start-%5BUsers%5D#4-dumping-firmware-modules)
 
 #### Works With
 * Steam ROM Manager
@@ -99,14 +96,7 @@ shadps4/
 ### shadPS4 File Formats
 [Back to the Top](#shadps4-table-of-contents)
 
-- [PKG Format](#pkg-and-rap-file-format)
-
-#### PKG and RAP File Format
-[Back to the Top](#shadps4-file-formats)
-
-Install `.pkg` files directly through the shadPS4 GUI. `.pkg` files are installed to `Emulation/storage/shadps4/games/`.
-
-After that right click on the installed game and select "Create Desktop", copy the new .desktop file you'll find in your Desktop to `Emulation/roms/ps4/shortcuts/`
+shadPS4 uses normal folder format for games, simply place your game folder in `Emulation/storage/shadps4/games` to have your games show up in the UI.
 
 ***
 
@@ -124,9 +114,7 @@ After that right click on the installed game and select "Create Desktop", copy t
 
 1. In `Desktop Mode`, open shadPS4
 2. Skip this step if you have already added your games to shadPS4:
-    * Either:
-        * In the top left click, `File`, click `Install Packages (PKG)`, and install your PKG
-        * For more information, read the [File Formats](#shadps4-file-formats) section
+    * Add your game folder to the `Emulation/storage/shadps4/games` folder. For more information, read the [File Formats](#shadps4-file-formats) section
 3. Right click your game, click `Create Shortcut`, click `Create Desktop Shortcut`
 4. On your desktop, you should see an icon for your game. Move this icon to `Emulation/roms/ps4/shortcuts`
     * If your desktop shortcut contains special icons any special symbols (Ex: the copyright symbol, `©`), rename the desktop file to remove these symbols.
@@ -143,7 +131,7 @@ After that right click on the installed game and select "Create Desktop", copy t
 
 If you get an `Invalid file or folder` error message, you will need to change the `Alternative Emulator` in ES-DE for PlayStation 4 to `shadPS4 Shortcut [Standalone]`.
 
-You may also do this on a per-game basis if you are using a mix of folders and PKGs. On a game, press the `select ` button, scroll down and select `EDIT THIS GAME'S METADATA`, scroll down and select `ALTERNATIVE EMULATOR`, select PS4 and select the corresponding format.
+On a game, press the `select ` button, scroll down and select `EDIT THIS GAME'S METADATA`, scroll down and select `ALTERNATIVE EMULATOR`, select PS4 and select the corresponding format.
 
 Refer to [https://gitlab.com/es-de/emulationstation-de/-/blob/master/USERGUIDE.md#sony-playstation-4](https://gitlab.com/es-de/emulationstation-de/-/blob/master/USERGUIDE.md#sony-playstation-4), for additional information.
 


### PR DESCRIPTION
This pull request aims to update the information concerning shadPS4 on EmuDeck for both SteamOS and Windows. I'm going to start by saying that I'm not an EmuDeck user, I was just curious about emulation on the deck and every Google search about it leads to EmuDeck, so I decided to see if the information for shadPS4 were up to date or not and I did some quick changes. The list of changes is:

- Updating the links that were outdated since shadPS4 has made a few changes to its compatibility list and its website.
- Making sure the name "shadPS4" is used, and not any other variation, such as "shadps4", "Shadps4", "ShadPS4" ...
- Removing every information that tells users to use the pkg extractor since this was removed in release 0.8.0 that came out on April 23rd 2025. 

Like I mentioned previously, I'm not an EmuDeck user (I'd rather have full control over what I install but I think the project is great to get people into emulation easily), so I haven't tested this, but considering the fact that the information were pretty outdated, it's possible that shadPS4 currently doesn't work on EmuDeck since the project has decided to remove the Qt binaries from the main repository and instead rely on a launcher. In order to to install shadPS4 you now have to install the shadPS4QtLauncher ([Link to the repo](https://github.com/shadps4-emu/shadps4-qtlauncher/)), and inside the launcher you select and install the emulator version you want to use, this could also be added to the docs. Lastly, the changes I made are rather bare bones, they don't explain everything clearly, I don't think I'm able to without fiddling with EmuDeck, but it should be easy to find all the info on the shadPS4 wiki and paste them here, or even redirect the users to that wiki (I think I've seen this done on EmuDeck before to tell users how to dump their PS2 games by linking the PCSX2 guide on their websites) for all the information I haven't provided about shadPS4.

